### PR TITLE
[fix] Render markdown correctly on thread list

### DIFF
--- a/Web/View/Threads/Index.hs
+++ b/Web/View/Threads/Index.hs
@@ -19,7 +19,7 @@ renderThread thread = [hsx|
         </a>
 
         <a class="thread-body" href={ShowThreadAction (get #id thread)}>
-            {get #body thread}
+            {get #body thread |> renderMarkdown}
         </a>
         <p class="text-muted">
             <a class="text-muted" href={ShowUserAction (get #id user)}>{get #name user}</a>


### PR DESCRIPTION
The thread list does not render markdown correctly, this just adds a
small fix to it by using the `renderMarkdown` function on the index
page as well