### PR TITLE
add Thread in New comment page

### DIFF
--- a/Web/Controller/Comments.hs
+++ b/Web/Controller/Comments.hs
@@ -15,6 +15,8 @@ instance Controller CommentsController where
         thread <- fetch threadId
         let comment = newRecord
                 |> set #threadId threadId
+        badges <- query @UserBadge
+            |> fetch
         render NewView { .. }
 
     action ShowCommentAction { commentId } = do

--- a/Web/Controller/Comments.hs
+++ b/Web/Controller/Comments.hs
@@ -13,10 +13,12 @@ instance Controller CommentsController where
 
     action NewCommentAction { threadId } = do
         thread <- fetch threadId
+            >>= fetchRelated #userId
         let comment = newRecord
                 |> set #threadId threadId
         badges <- query @UserBadge
             |> fetch
+            >>= collectionFetchRelated #userId
         render NewView { .. }
 
     action ShowCommentAction { commentId } = do
@@ -51,7 +53,11 @@ instance Controller CommentsController where
             |> ifValid \case
                 Left comment -> do
                     thread <- fetch (get #threadId comment)
-                    render NewView { .. } 
+                        >>= fetchRelated #userId
+                    badges <- query @UserBadge
+                        |> fetch
+                        >>= collectionFetchRelated #userId
+                    render NewView { .. }
                 Right comment -> do
                     comment <- comment |> createRecord
 

--- a/Web/Controller/Comments.hs
+++ b/Web/Controller/Comments.hs
@@ -28,6 +28,10 @@ instance Controller CommentsController where
     action EditCommentAction { commentId } = do
         comment <- fetch commentId
         thread <- fetch (get #threadId comment)
+                  >>= fetchRelated #userId
+        badges <- query @UserBadge
+                  |> fetch
+                  >>= collectionFetchRelated #userId
         render EditView { .. }
 
     action UpdateCommentAction { commentId } = do
@@ -37,6 +41,10 @@ instance Controller CommentsController where
             |> ifValid \case
                 Left comment -> do
                     thread <- fetch (get #threadId comment)
+                              >>= fetchRelated #userId
+                    badges <- query @UserBadge
+                              |> fetch
+                              >>= collectionFetchRelated #userId
                     render EditView { .. }
                 Right comment -> do
                     comment <- comment |> updateRecord

--- a/Web/View/Comments/Edit.hs
+++ b/Web/View/Comments/Edit.hs
@@ -42,5 +42,5 @@ instance View EditView ViewContext where
                 {hiddenField #threadId}
                 {(textareaField #body) { fieldLabel = "Your Comment:", helpText = "You can use markdown here." } }
                 {submitButton}
-                <a href={ShowThreadAction (get #id thread)}><button class="ml-3 btn btn-secondary">Go back to Thread</button></a>
+                <a class="ml-3 btn btn-secondary" href={ShowThreadAction (get #id thread)}>Go back to Thread</a>
             |]

--- a/Web/View/Comments/Edit.hs
+++ b/Web/View/Comments/Edit.hs
@@ -9,10 +9,6 @@ data EditView = EditView
 
 instance View EditView ViewContext where
     html EditView { .. } = [hsx|
-        <a href={ShowThreadAction (get #id thread)}>
-            Go back to <q>{get #title thread}</q>
-        </a>
-        <h1>Edit Comment</h1>
         <div class="row thread mb-5">
             <div class="col-3 user-col">
                 <a class="user-col" href={ShowUserAction (get #id author)}>
@@ -36,16 +32,15 @@ instance View EditView ViewContext where
       where
             author = get #userId thread
 
-renderForm :: Comment -> Html
-renderForm comment = formFor comment [hsx|
-    {hiddenField #threadId}
-    {hiddenField #userId}
-    {textareaField #body}
-    {submitButton}
-|]
             renderBadges author userbadge
                      | (author == (get #userId userbadge)) = [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
                         where
                             badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
             renderBadges _ _ = [hsx||]
 
+            renderForm comment = formFor comment [hsx|
+                {hiddenField #threadId}
+                {(textareaField #body) { fieldLabel = "Your Comment:", helpText = "You can use markdown here." } }
+                {submitButton}
+                <a href={ShowThreadAction (get #id thread)}><button class="ml-3 btn btn-secondary">Go back to Thread</button></a>
+            |]

--- a/Web/View/Comments/Edit.hs
+++ b/Web/View/Comments/Edit.hs
@@ -3,7 +3,8 @@ import Web.View.Prelude
 
 data EditView = EditView
     { comment :: Comment
-    , thread :: Thread
+    , thread :: Include "userId" Thread
+    , badges :: [Include "userId" UserBadge]
     }
 
 instance View EditView ViewContext where
@@ -12,8 +13,28 @@ instance View EditView ViewContext where
             Go back to <q>{get #title thread}</q>
         </a>
         <h1>Edit Comment</h1>
+        <div class="row thread mb-5">
+            <div class="col-3 user-col">
+                <a class="user-col" href={ShowUserAction (get #id author)}>
+                    {renderPicture author}
+                    {get #name author}
+                </a>
+                <tr> {forEach badges (renderBadges author)} </tr>
+            </div>
+
+            <div class="col-9 thread-content">
+                <div class="text-muted thread-created-at">
+                    {get #createdAt thread |> timeAgo}
+                </div>
+                <h1 class="thread-title">{get #title thread}</h1>
+                <div class="thread-body">{get #body thread |> renderMarkdown}</div>
+            </div>
+        </div>
+
         {renderForm comment}
     |]
+      where
+            author = get #userId thread
 
 renderForm :: Comment -> Html
 renderForm comment = formFor comment [hsx|
@@ -22,3 +43,9 @@ renderForm comment = formFor comment [hsx|
     {textareaField #body}
     {submitButton}
 |]
+            renderBadges author userbadge
+                     | (author == (get #userId userbadge)) = [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
+                        where
+                            badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
+            renderBadges _ _ = [hsx||]
+

--- a/Web/View/Comments/Edit.hs
+++ b/Web/View/Comments/Edit.hs
@@ -32,8 +32,7 @@ instance View EditView ViewContext where
       where
             author = get #userId thread
 
-            renderBadges author userbadge
-                     | (author == (get #userId userbadge)) = [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
+            renderBadges author userbadge= when (author == (get #userId userbadge)) [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
                         where
                             badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
             renderBadges _ _ = [hsx||]

--- a/Web/View/Comments/New.hs
+++ b/Web/View/Comments/New.hs
@@ -3,7 +3,7 @@ import Web.View.Prelude
 
 data NewView = NewView
   { comment :: Comment
-  , thread :: Thread
+  , thread :: Include "userId" Thread
   , badges :: [Include "userId" UserBadge]
   }
 

--- a/Web/View/Comments/New.hs
+++ b/Web/View/Comments/New.hs
@@ -42,5 +42,5 @@ instance View NewView ViewContext where
                 {hiddenField #threadId}
                 {(textareaField #body) { fieldLabel = "Your Comment:", helpText = "You can use markdown here." } }
                 {submitButton}
-                <a href={ShowThreadAction (get #id thread)}><button class="ml-3 btn btn-secondary">Go back to Thread</button></a>
+                <a class="ml-3 btn btn-secondary" href={ShowThreadAction (get #id thread)}>Go back to Thread</a>
             |]

--- a/Web/View/Comments/New.hs
+++ b/Web/View/Comments/New.hs
@@ -9,7 +9,6 @@ data NewView = NewView
 
 instance View NewView ViewContext where
     html NewView { .. } = [hsx|
-        <a href={ShowThreadAction (get #id thread)}>Go back to Thread</a>
         <div class="row thread mb-5">
             <div class="col-3 user-col">
                 <a class="user-col" href={ShowUserAction (get #id author)}>
@@ -18,13 +17,13 @@ instance View NewView ViewContext where
                 </a>
                 <tr> {forEach badges (renderBadges author)} </tr>
             </div>
-
             <div class="col-9 thread-content">
                 <div class="text-muted thread-created-at">
                     {get #createdAt thread |> timeAgo}
                 </div>
                 <h1 class="thread-title">{get #title thread}</h1>
                 <div class="thread-body">{get #body thread |> renderMarkdown}</div>
+
             </div>
         </div>
 
@@ -39,10 +38,9 @@ instance View NewView ViewContext where
                             badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
             renderBadges _ _ = [hsx||]
 
-
-renderForm :: Comment -> Html
-renderForm comment = formFor comment [hsx|
-    {hiddenField #threadId}
-    {(textareaField #body) { fieldLabel = "Your Comment:", helpText = "You can use markdown here." } }
-    {submitButton}
-|]
+            renderForm comment = formFor comment [hsx|
+                {hiddenField #threadId}
+                {(textareaField #body) { fieldLabel = "Your Comment:", helpText = "You can use markdown here." } }
+                {submitButton}
+                <a href={ShowThreadAction (get #id thread)}><button class="ml-3 btn btn-secondary">Go back to Thread</button></a>
+            |]

--- a/Web/View/Comments/New.hs
+++ b/Web/View/Comments/New.hs
@@ -32,8 +32,7 @@ instance View NewView ViewContext where
       where
             author = get #userId thread
 
-            renderBadges author userbadge
-                     | (author == (get #userId userbadge)) = [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
+            renderBadges author userbadge= when (author == (get #userId userbadge)) [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
                         where
                             badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
             renderBadges _ _ = [hsx||]

--- a/Web/View/Comments/New.hs
+++ b/Web/View/Comments/New.hs
@@ -1,14 +1,44 @@
 module Web.View.Comments.New where
 import Web.View.Prelude
 
-data NewView = NewView { comment :: Comment, thread :: Thread }
+data NewView = NewView
+  { comment :: Comment
+  , thread :: Thread
+  , badges :: [Include "userId" UserBadge]
+  }
 
 instance View NewView ViewContext where
     html NewView { .. } = [hsx|
         <a href={ShowThreadAction (get #id thread)}>Go back to Thread</a>
-        <h1>{get #title thread}</h1>
+        <div class="row thread mb-5">
+            <div class="col-3 user-col">
+                <a class="user-col" href={ShowUserAction (get #id author)}>
+                    {renderPicture author}
+                    {get #name author}
+                </a>
+                <tr> {forEach badges (renderBadges author)} </tr>
+            </div>
+
+            <div class="col-9 thread-content">
+                <div class="text-muted thread-created-at">
+                    {get #createdAt thread |> timeAgo}
+                </div>
+                <h1 class="thread-title">{get #title thread}</h1>
+                <div class="thread-body">{get #body thread |> renderMarkdown}</div>
+            </div>
+        </div>
+
         {renderForm comment}
     |]
+      where
+            author = get #userId thread
+
+            renderBadges author userbadge
+                     | (author == (get #userId userbadge)) = [hsx| <span class={snd badgeTuple}> {fst badgeTuple} </span> |]
+                        where
+                            badgeTuple = fromMaybe ("", "") (lookup (get #badge userbadge) badgeMap)
+            renderBadges _ _ = [hsx||]
+
 
 renderForm :: Comment -> Html
 renderForm comment = formFor comment [hsx|

--- a/static/app.css
+++ b/static/app.css
@@ -169,3 +169,21 @@ code.language-haskell .st { color: #2aa198; }
 .btn.btn-primary:hover {
     background-color: hsla(192, 81%, 26%, 0.8);
 }
+
+.btn.btn-secondary {
+    background-color: transparent;
+    color: hsla(192, 81%, 19%, 0.8);
+    border: 1px solid hsla(192, 81%, 19%, 0.8);
+    font-weight: 500;
+}
+
+.btn.btn-secondary:active {
+    background-color: transparent;
+    color: hsla(192, 81%, 19%, 0.8) !important;
+    border: 1px solid hsla(192, 81%, 19%, 0.8) !important;
+}
+
+.btn.btn-secondary:hover {
+    background-color: hsla(192, 81%, 19%, 0.1);
+    color: hsla(192, 81%, 19%, 1);
+}


### PR DESCRIPTION
~@mpscholten could you explain why I'm getting, I don't really understand where type `User` comes in when I'm only working with the author's `userId` .~

Changes:
- Renders thread in NewComment and EditComment
- Adds button for "go back to thread"
- Adds styling for secondary button

Fixes: https://github.com/digitallyinduced/ihp-forum/issues/11