### PR TITLE
Migrate to authMiddleware from initAuthentication

### DIFF
--- a/Admin/FrontController.hs
+++ b/Admin/FrontController.hs
@@ -9,7 +9,6 @@ import Admin.View.Layout
 
 -- Controller Imports
 import Admin.Controller.Admins
-import IHP.LoginSupport.Middleware
 import Admin.Controller.Sessions
 
 instance FrontController AdminApplication where
@@ -23,4 +22,3 @@ instance FrontController AdminApplication where
 instance InitControllerContext AdminApplication where
     initContext = do
         setLayout defaultLayout
-        initAuthentication @Admin

--- a/Admin/View/Layout.hs
+++ b/Admin/View/Layout.hs
@@ -31,8 +31,6 @@ defaultLayout inner = [hsx|
 </body>
 </html>
 |]
-    where
-        currentAdminOrNothing = fromFrozenContext @(Maybe Admin)
 
 renderLoggedInAs :: Maybe Admin -> Html
 renderLoggedInAs (Just admin) = [hsx|

--- a/Application/Helper/Controller.hs
+++ b/Application/Helper/Controller.hs
@@ -7,14 +7,12 @@ module Application.Helper.Controller
 import IHP.LoginSupport.Helper.Controller
 import IHP.Prelude
 import Generated.Types
+import Application.Helper.TypeInstances ()
 
 import qualified Network.Wreq as Wreq
 import qualified Config
 import qualified Control.Concurrent.Async as Async
 import Data.Aeson
-
-type instance CurrentUserRecord = User
-type instance CurrentAdminRecord = Admin
 
 sendToSlack :: Text -> IO ()
 sendToSlack message = case Config.slackWebHook of

--- a/Application/Helper/TypeInstances.hs
+++ b/Application/Helper/TypeInstances.hs
@@ -1,0 +1,13 @@
+-- | Orphan instances for 'IHP.LoginSupport.Types.CurrentUserRecord' and
+-- 'IHP.LoginSupport.Types.CurrentAdminRecord'.
+--
+-- Keeping these in their own tiny module avoids import cycles when
+-- `Config/Config.hs` (which can't import `Application.Helper.Controller`)
+-- needs the instances in scope for 'authMiddleware @User'.
+module Application.Helper.TypeInstances () where
+
+import Generated.Types
+import IHP.LoginSupport.Types
+
+type instance CurrentUserRecord = User
+type instance CurrentAdminRecord = Admin

--- a/Config/Config.hs
+++ b/Config/Config.hs
@@ -4,7 +4,7 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import qualified IHP.LoginSupport.Middleware as Auth
-import Application.Helper.Controller ()
+import Application.Helper.TypeInstances ()
 import Generated.Types
 
 config :: ConfigBuilder

--- a/Config/Config.hs
+++ b/Config/Config.hs
@@ -3,14 +3,14 @@ module Config where
 import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
-import IHP.LoginSupport.Middleware (authMiddleware, adminAuthMiddleware)
+import qualified IHP.LoginSupport.Middleware as Auth
 import Generated.Types
 
 config :: ConfigBuilder
 config = do
     -- See https://ihp.digitallyinduced.com/Guide/config.html
     -- for what you can do here
-    option $ AuthMiddleware (authMiddleware @User . adminAuthMiddleware @Admin)
+    option $ AuthMiddleware (Auth.authMiddleware @User . Auth.adminAuthMiddleware @Admin)
 
 slackWebHook :: Maybe String
 slackWebHook = Nothing

--- a/Config/Config.hs
+++ b/Config/Config.hs
@@ -3,12 +3,14 @@ module Config where
 import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
+import IHP.LoginSupport.Middleware (authMiddleware, adminAuthMiddleware)
+import Generated.Types
 
 config :: ConfigBuilder
 config = do
     -- See https://ihp.digitallyinduced.com/Guide/config.html
     -- for what you can do here
-    pure ()
+    option $ AuthMiddleware (authMiddleware @User . adminAuthMiddleware @Admin)
 
 slackWebHook :: Maybe String
 slackWebHook = Nothing

--- a/Config/Config.hs
+++ b/Config/Config.hs
@@ -4,6 +4,7 @@ import IHP.Prelude
 import IHP.Environment
 import IHP.FrameworkConfig
 import qualified IHP.LoginSupport.Middleware as Auth
+import Application.Helper.Controller ()
 import Generated.Types
 
 config :: ConfigBuilder

--- a/Web/FrontController.hs
+++ b/Web/FrontController.hs
@@ -11,7 +11,6 @@ import Web.Controller.Topics
 import Web.Controller.Comments
 import Web.Controller.Users
 import Web.Controller.Threads
-import IHP.LoginSupport.Middleware
 import Web.Controller.Sessions
 
 instance FrontController WebApplication where
@@ -28,4 +27,3 @@ instance FrontController WebApplication where
 instance InitControllerContext WebApplication where
     initContext = do
         setLayout defaultLayout
-        initAuthentication @User


### PR DESCRIPTION
## Summary

IHP master removes `initAuthentication` / `fromFrozenContext` (in digitallyinduced/ihp#2633) as part of eliminating the ControllerContext TMap. This PR migrates the forum to the new API:

- `Config/Config.hs`: register `AuthMiddleware (authMiddleware @User . adminAuthMiddleware @Admin)`
- `Web/FrontController.hs`, `Admin/FrontController.hs`: drop the `initAuthentication` call
- `Admin/View/Layout.hs`: use `currentAdminOrNothing` (re-exported from `IHP.ViewPrelude` via `IHP.LoginSupport.Helper.View`) instead of the removed `fromFrozenContext @(Maybe Admin)`

Needed before the `core-size` benchmark in ihp#2633 can pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)